### PR TITLE
Fix model path for ASL conversion

### DIFF
--- a/modules/asl_processor.py
+++ b/modules/asl_processor.py
@@ -1,7 +1,18 @@
+"""Utilities for converting English text to ASL grammar."""
+
+import os
 from transformers import pipeline
 
-asl_converter = pipeline("text2text-generation", model="./asl_bart")
+# Resolve the model path relative to this file so the module works
+# regardless of the current working directory.
+MODEL_DIR = os.path.join(os.path.dirname(__file__), "..", "models", "asl_flan_t5")
 
-def convert_to_asl_grammar(text):
-    result = asl_converter(text, max_length=50)
-    return result[0]['generated_text'].strip().upper()
+# Create the text2text-generation pipeline
+asl_converter = pipeline("text2text-generation", model=MODEL_DIR)
+
+
+def convert_to_asl_grammar(text: str) -> str:
+    """Convert English sentence to ASL-friendly grammar using the fine-tuned model."""
+    prompt = f"Convert to ASL grammar: {text}"
+    result = asl_converter(prompt, max_length=50)
+    return result[0]["generated_text"].strip().upper()


### PR DESCRIPTION
## Summary
- fix modules/asl_processor.py to load `models/asl_flan_t5`
- update `convert_to_asl_grammar` to use ASL prompt and model path relative to file

## Testing
- `python -m py_compile modules/asl_processor.py`
- `python -m py_compile app.py modules/asl_processor.py inference/asl_processor_flant5.py inference/compare_models.py scripts/live_transcription.py scripts/speech_to_text.py scripts/generate_gifs.py scripts/prepare_aslg_pc12.py training/train_bart_asl.py training/train_flan_t5_asl.py`


------
https://chatgpt.com/codex/tasks/task_e_684a264d021883208b8115e4056faaca